### PR TITLE
Displays the Aux string in the pre-edit area.

### DIFF
--- a/src/eim.cpp
+++ b/src/eim.cpp
@@ -416,11 +416,18 @@ void ChewingEngine::updateUI(InputContext *ic) {
     preedit.append(zuin, {TextFormatFlag::HighLight, format});
     preedit.append(text.substr(rcur), format);
 
+    if (chewing_aux_Check(ctx)) {
+        const char *aux_str = chewing_aux_String_static(ctx);
+        std::string aux = aux_str;
+        ic->inputPanel().setAuxDown(Text(aux));
+    }
+
     if (useClientPreedit) {
         ic->inputPanel().setClientPreedit(preedit);
     } else {
         ic->inputPanel().setPreedit(preedit);
     }
+
     ic->updatePreedit();
 }
 


### PR DESCRIPTION
Actually libchewing may prompt some useful messages and we can get them
from the API chewing_aux_String_static. For example, when a user adds a
new custom phrase, it shows a message like "added successfully" or "the
phrase already exist". The PR brings such user interface to fcitx5.