### PR TITLE
feat: Add Colemak

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -73,6 +73,10 @@ msgid "Clear"
 msgstr ""
 
 #: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr ""
+
+#: src/eim.h:84
 msgid "Colemak-DH ANSI Keyboard"
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -72,6 +72,10 @@ msgid "Clear"
 msgstr ""
 
 #: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr ""
+
+#: src/eim.h:84
 msgid "Colemak-DH ANSI Keyboard"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -74,6 +74,10 @@ msgid "Clear"
 msgstr ""
 
 #: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr ""
+
+#: src/eim.h:84
 msgid "Colemak-DH ANSI Keyboard"
 msgstr ""
 

--- a/po/fcitx5-chewing.pot
+++ b/po/fcitx5-chewing.pot
@@ -68,6 +68,10 @@ msgid "Clear"
 msgstr ""
 
 #: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr ""
+
+#: src/eim.h:84
 msgid "Colemak-DH ANSI Keyboard"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -74,6 +74,10 @@ msgid "Clear"
 msgstr ""
 
 #: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr ""
+
+#: src/eim.h:84
 msgid "Colemak-DH ANSI Keyboard"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -74,6 +74,10 @@ msgid "Clear"
 msgstr ""
 
 #: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr ""
+
+#: src/eim.h:84
 msgid "Colemak-DH ANSI Keyboard"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -74,6 +74,10 @@ msgid "Clear"
 msgstr ""
 
 #: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr ""
+
+#: src/eim.h:84
 msgid "Colemak-DH ANSI Keyboard"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -74,6 +74,10 @@ msgstr "Метод ввода Chewing"
 msgid "Clear"
 msgstr "Очистить"
 
+#: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr "Клавиатура Colemak"
+
 #: src/eim.h:104
 msgid "Colemak-DH ANSI Keyboard"
 msgstr "Клавиатура Colemak-DH ANSI"

--- a/po/tr.po
+++ b/po/tr.po
@@ -73,6 +73,10 @@ msgid "Clear"
 msgstr ""
 
 #: src/eim.h:84
+msgid "Colemak Keyboard"
+msgstr ""
+
+#: src/eim.h:84
 msgid "Colemak-DH ANSI Keyboard"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -74,6 +74,10 @@ msgid "Clear"
 msgstr "清空"
 
 #: src/eim.h:104
+msgid "Colemak Keyboard"
+msgstr "Colemak 键盘"
+
+#: src/eim.h:104
 msgid "Colemak-DH ANSI Keyboard"
 msgstr "Colemak-DH ANSI 键盘"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -78,6 +78,10 @@ msgid "Clear"
 msgstr "清除"
 
 #: src/eim.h:104
+msgid "Colemak Keyboard"
+msgstr "Colemak 鍵盤"
+
+#: src/eim.h:104
 msgid "Colemak-DH ANSI Keyboard"
 msgstr "Colemak-DH ANSI 鍵盤"
 

--- a/src/eim.h
+++ b/src/eim.h
@@ -71,6 +71,7 @@ enum class ChewingLayout {
     ThlPinYin,
     Mps2PinYin,
     Carpalx,
+    Colemak,
     ColemakDH_ANSI,
     ColemakDH_ORTH
 };
@@ -88,6 +89,7 @@ static constexpr const char *builtin_keymaps[] = {"KB_DEFAULT",
                                                   "KB_THL_PINYIN",
                                                   "KB_MPS2_PINYIN",
                                                   "KB_CARPALX",
+                                                  "KB_COLEMAK",
                                                   "KB_COLEMAK_DH_ANSI",
                                                   "KB_COLEMAK_DH_ORTH"};
 
@@ -97,7 +99,7 @@ FCITX_CONFIG_ENUM_NAME(ChewingLayout, "Default Keyboard", "Hsu's Keyboard",
                        "Dvorak Keyboard with Hsu's support",
                        "DACHEN_CP26 Keyboard", "Han-Yu PinYin Keyboard",
                        "THL PinYin Keyboard", "MPS2 PinYin Keyboard",
-                       "Carpalx Keyboard", "Colemak-DH ANSI Keyboard",
+                       "Carpalx Keyboard", "Colemak Keyboard", "Colemak-DH ANSI Keyboard",
                        "Colemak-DH Orth Keyboard");
 FCITX_CONFIG_ENUM_I18N_ANNOTATION(
     ChewingLayout, N_("Default Keyboard"), N_("Hsu's Keyboard"),
@@ -106,7 +108,7 @@ FCITX_CONFIG_ENUM_I18N_ANNOTATION(
     N_("Dvorak Keyboard with Hsu's support"), N_("DACHEN_CP26 Keyboard"),
     N_("Han-Yu PinYin Keyboard"), N_("THL PinYin Keyboard"),
     N_("MPS2 PinYin Keyboard"), N_("Carpalx Keyboard"),
-    N_("Colemak-DH ANSI Keyboard"), N_("Colemak-DH Orth Keyboard"));
+    N_("Colemak Keyboard"), N_("Colemak-DH ANSI Keyboard"), N_("Colemak-DH Orth Keyboard"));
 
 class ChewingLayoutOption : public Option<ChewingLayout> {
     using Base = Option<ChewingLayout>;


### PR DESCRIPTION
TLDR I try adding Colemak as a keyboard layout.
Pull request on libchewing: https://github.com/chewing/libchewing/pull/674
----------------------------------
Do the line counts, e.g. src/eim.h:84 matter or just outdated?
Does the order matter? Should Colemak be placed below the other layouts for a particular reason?
Thanks :D