### PR TITLE
Locate libchewing syspath with tsi.dat

### DIFF
--- a/src/eim.cpp
+++ b/src/eim.cpp
@@ -293,7 +293,7 @@ void logger(void * /*context*/, int /*level*/, const char *fmt, ...) {
 ChewingContext *getChewingContext() {
     const auto &sp = StandardPaths::global();
     std::filesystem::path dictData =
-        sp.locate(StandardPathsType::Data, "libchewing/dictionary.dat");
+        sp.locate(StandardPathsType::Data, "libchewing/tsi.dat");
     if (!dictData.empty()) {
         std::string sysPath = dictData.parent_path().string();
         return chewing_new2(sysPath.c_str(), nullptr, nullptr, nullptr);


### PR DESCRIPTION
dictionary.dat was removed since libchewing 0.9.0, but tsi.dat is still present

ref: https://github.com/chewing/libchewing/commit/b21ff8f118e6138b795da4d37026712516a12676