### PR TITLE
fix: preserve Chewing config after reset and improve Hsu input

### DIFF
--- a/src/eim.cpp
+++ b/src/eim.cpp
@@ -30,6 +30,7 @@
 #include <fcitx/userinterfacemanager.h>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -72,6 +73,42 @@ DEFINE_SAFE_CHEWING_STRING_GETTER(aux);
 DEFINE_SAFE_CHEWING_STRING_GETTER(buffer);
 DEFINE_SAFE_CHEWING_STRING_GETTER(bopomofo);
 DEFINE_SAFE_CHEWING_STRING_GETTER(commit);
+
+bool isAsciiPunctuation(uint32_t unicode) {
+    return (unicode >= 0x21 && unicode <= 0x2f) ||
+           (unicode >= 0x3a && unicode <= 0x40) ||
+           (unicode >= 0x5b && unicode <= 0x60) ||
+           (unicode >= 0x7b && unicode <= 0x7e);
+}
+
+std::optional<char> literalForKey(const KeyEvent &keyEvent) {
+    const auto key = keyEvent.key();
+    if (!key.isSimple()) {
+        return std::nullopt;
+    }
+    const auto unicode = Key::keySymToUnicode(key.sym());
+    if (key.isUAZ() || isAsciiPunctuation(unicode)) {
+        return static_cast<char>(unicode);
+    }
+    return std::nullopt;
+}
+
+bool isHsuFirstToneKey(const ChewingConfig &config, const KeyEvent &keyEvent) {
+    if (*config.Layout != ChewingLayout::Hsu || !keyEvent.key().isSimple()) {
+        return false;
+    }
+    const auto unicode = Key::keySymToUnicode(keyEvent.key().sym());
+    return unicode == 'q' || unicode == 'Q';
+}
+
+int chewingKeyCodeForEvent(const ChewingConfig &config,
+                           const KeyEvent &keyEvent) {
+    const auto key = keyEvent.key();
+    if (*config.Layout == ChewingLayout::Hsu && key.isUAZ()) {
+        return Key::keySymToUnicode(key.sym()) - 'A' + 'a';
+    }
+    return key.sym() & 0xff;
+}
 
 class ChewingCandidateWord : public CandidateWord {
 public:
@@ -352,6 +389,7 @@ void ChewingEngine::doReset(InputContextEvent &event) {
     chewing_clean_preedit_buf(ctx);
     chewing_clean_bopomofo_buf(ctx);
     chewing_Reset(ctx);
+    populateConfig();
     updateUI(event.inputContext());
 }
 
@@ -447,11 +485,24 @@ bool ChewingEngine::handleCandidateKeyEvent(const KeyEvent &keyEvent) const {
         }
         return true;
     }
-    if (keyEvent.key().check(FcitxKey_space)) {
-        candidateList->next();
-        return true;
-    }
     return false;
+}
+
+void ChewingEngine::commitLiteralAndReset(KeyEvent &keyEvent, char literal) {
+    auto *ctx = context_.get();
+    auto *ic = keyEvent.inputContext();
+    if (chewing_buffer_Check(ctx) || chewing_bopomofo_Check(ctx)) {
+        chewing_commit_preedit_buf(ctx);
+        if (chewing_commit_Check(ctx)) {
+            ic->commitString(safeChewing_commit_String(ctx));
+        }
+    }
+    ic->commitString(std::string(1, literal));
+    chewing_cand_close(ctx);
+    chewing_clean_preedit_buf(ctx);
+    chewing_clean_bopomofo_buf(ctx);
+    keyEvent.filterAndAccept();
+    updateUI(ic);
 }
 
 void ChewingEngine::keyEvent(const InputMethodEntry &entry,
@@ -470,16 +521,25 @@ void ChewingEngine::keyEvent(const InputMethodEntry &entry,
         return;
     }
 
+    if (auto literal = literalForKey(keyEvent)) {
+        commitLiteralAndReset(keyEvent, *literal);
+        return;
+    }
+
     int chewingReturnValue = 0;
-    if (keyEvent.key().check(FcitxKey_space)) {
+    if ((isHsuFirstToneKey(config_, keyEvent) ||
+         keyEvent.key().check(FcitxKey_space)) &&
+        chewing_bopomofo_Check(ctx)) {
         chewingReturnValue = chewing_handle_Space(ctx);
+    } else if (keyEvent.key().check(FcitxKey_space)) {
+        return;
     } else if (keyEvent.key().check(FcitxKey_Tab)) {
         chewingReturnValue = chewing_handle_Tab(ctx);
     } else if (keyEvent.key().isSimple()) {
         if (keyEvent.rawKey().states().test(KeyState::Shift)) {
             chewing_set_easySymbolInput(ctx, *config_.EasySymbolInput ? 1 : 0);
         }
-        int scan_code = keyEvent.key().sym() & 0xff;
+        int scan_code = chewingKeyCodeForEvent(config_, keyEvent);
         if (*config_.Layout == ChewingLayout::HanYuPinYin) {
             auto zuin = safeChewing_bopomofo_String(ctx);
             // Workaround a bug in libchewing fixed in 2017 but never has

--- a/src/eim.h
+++ b/src/eim.h
@@ -213,6 +213,7 @@ public:
 
 private:
     bool handleCandidateKeyEvent(const KeyEvent &keyEvent) const;
+    void commitLiteralAndReset(KeyEvent &keyEvent, char literal);
     void updatePreeditImpl(InputContext *ic);
 
     FCITX_ADDON_DEPENDENCY_LOADER(chttrans, instance_->addonManager());


### PR DESCRIPTION
## Summary

This fixes Android-triggered Chewing runtime config loss after reset and improves Android virtual-keyboard literal handling.

Main fix:

- reapply Chewing runtime config after `chewing_Reset()` so Android input-context resets keep the selected keyboard layout

Related input fixes:

- make Hsu `q` / `Q` work as first-tone finalization while composing bopomofo
- pass ASCII punctuation, numbers, spaces, and uppercase long-press letters through as half-width literal text
- stop using Space to page/select candidates; Space only finalizes the current bopomofo syllable, otherwise it commits a half-width space

## Root cause

Fcitx5 for Android can reset the Chewing engine during normal input-context lifecycle changes. In practice, the Chewing plugin could load the configured keyboard layout correctly for the first input after reload, but later input would behave as if the engine had fallen back to the default layout.

The issue is that `chewing_Reset()` resets libchewing runtime state, but the wrapper did not reapply runtime options afterwards. Settings such as the selected keyboard layout are applied through libchewing runtime calls, so they need to be restored after reset as well as after config reload.

This is especially visible with Hsu keyboard because its key mapping differs significantly from the default layout. After reset, Hsu input can stop composing correctly even though the Android plugin setting still shows Hsu selected.

## Behavior after this change

After every Chewing reset, the plugin calls `populateConfig()` again before updating UI state. This keeps the libchewing context aligned with the configured Chewing options across input-context resets.

The remaining changes keep Android virtual-keyboard behavior consistent with that reset fix and with half-width ASCII expectations:

- Hsu `q` / `Q` is treated as a first-tone finalization key while composing bopomofo
- Android long-press uppercase letters commit uppercase ASCII instead of being interpreted as zhuyin input
- ASCII punctuation, numbers, and spaces commit half-width ASCII instead of being converted by Chewing symbol handling
- Space no longer pages/selects candidates; when not composing bopomofo, it commits a normal half-width space

## Validation

- `clang-format --dry-run --Werror src/eim.cpp src/eim.h`
- attempted Android plugin build with `./gradlew :plugin:chewing:assembleRelease --no-daemon`; local validation is currently blocked because `extra-cmake-modules` / ECM is not installed in this environment
- previously manually installed a locally signed arm64 fcitx5-android Chewing plugin APK and tested:
  - selected Hsu layout remains effective after reload/reset
  - Hsu `q` / `Q` first-tone behavior
  - ASCII punctuation stays half-width
  - long-press uppercase letters commit uppercase ASCII
  - Space does not page/select candidates
