### PR TITLE
fix: preserve Chewing config after reset and improve Hsu input

### DIFF
--- a/src/eim.cpp
+++ b/src/eim.cpp
@@ -30,6 +30,7 @@
 #include <fcitx/userinterfacemanager.h>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -72,6 +73,50 @@ DEFINE_SAFE_CHEWING_STRING_GETTER(aux);
 DEFINE_SAFE_CHEWING_STRING_GETTER(buffer);
 DEFINE_SAFE_CHEWING_STRING_GETTER(bopomofo);
 DEFINE_SAFE_CHEWING_STRING_GETTER(commit);
+
+bool isAsciiPunctuation(uint32_t unicode) {
+    return (unicode >= 0x21 && unicode <= 0x2f) ||
+           (unicode >= 0x3a && unicode <= 0x40) ||
+           (unicode >= 0x5b && unicode <= 0x60) ||
+           (unicode >= 0x7b && unicode <= 0x7e);
+}
+
+bool isPinyinLayout(const ChewingConfig &config) {
+    return *config.Layout == ChewingLayout::HanYuPinYin ||
+           *config.Layout == ChewingLayout::ThlPinYin ||
+           *config.Layout == ChewingLayout::Mps2PinYin;
+}
+
+std::optional<char> literalForKey(const ChewingConfig &config,
+                                  const KeyEvent &keyEvent) {
+    const auto key = keyEvent.key();
+    if (!key.isSimple()) {
+        return std::nullopt;
+    }
+    const auto unicode = Key::keySymToUnicode(key.sym());
+    if (key.isUAZ() || isAsciiPunctuation(unicode) ||
+        (!isPinyinLayout(config) && (unicode == ' ' || key.isDigit()))) {
+        return static_cast<char>(unicode);
+    }
+    return std::nullopt;
+}
+
+bool isHsuFirstToneKey(const ChewingConfig &config, const KeyEvent &keyEvent) {
+    if (*config.Layout != ChewingLayout::Hsu || !keyEvent.key().isSimple()) {
+        return false;
+    }
+    const auto unicode = Key::keySymToUnicode(keyEvent.key().sym());
+    return unicode == 'q' || unicode == 'Q';
+}
+
+int chewingKeyCodeForEvent(const ChewingConfig &config,
+                           const KeyEvent &keyEvent) {
+    const auto key = keyEvent.key();
+    if (*config.Layout == ChewingLayout::Hsu && key.isUAZ()) {
+        return Key::keySymToUnicode(key.sym()) - 'A' + 'a';
+    }
+    return key.sym() & 0xff;
+}
 
 class ChewingCandidateWord : public CandidateWord {
 public:
@@ -352,6 +397,7 @@ void ChewingEngine::doReset(InputContextEvent &event) {
     chewing_clean_preedit_buf(ctx);
     chewing_clean_bopomofo_buf(ctx);
     chewing_Reset(ctx);
+    populateConfig();
     updateUI(event.inputContext());
 }
 
@@ -447,11 +493,24 @@ bool ChewingEngine::handleCandidateKeyEvent(const KeyEvent &keyEvent) const {
         }
         return true;
     }
-    if (keyEvent.key().check(FcitxKey_space)) {
-        candidateList->next();
-        return true;
-    }
     return false;
+}
+
+void ChewingEngine::commitLiteralAndReset(KeyEvent &keyEvent, char literal) {
+    auto *ctx = context_.get();
+    auto *ic = keyEvent.inputContext();
+    if (chewing_buffer_Check(ctx) || chewing_bopomofo_Check(ctx)) {
+        chewing_commit_preedit_buf(ctx);
+        if (chewing_commit_Check(ctx)) {
+            ic->commitString(safeChewing_commit_String(ctx));
+        }
+    }
+    ic->commitString(std::string(1, literal));
+    chewing_cand_close(ctx);
+    chewing_clean_preedit_buf(ctx);
+    chewing_clean_bopomofo_buf(ctx);
+    keyEvent.filterAndAccept();
+    updateUI(ic);
 }
 
 void ChewingEngine::keyEvent(const InputMethodEntry &entry,
@@ -471,15 +530,20 @@ void ChewingEngine::keyEvent(const InputMethodEntry &entry,
     }
 
     int chewingReturnValue = 0;
-    if (keyEvent.key().check(FcitxKey_space)) {
+    if ((isHsuFirstToneKey(config_, keyEvent) ||
+         keyEvent.key().check(FcitxKey_space)) &&
+        chewing_bopomofo_Check(ctx)) {
         chewingReturnValue = chewing_handle_Space(ctx);
+    } else if (auto literal = literalForKey(config_, keyEvent)) {
+        commitLiteralAndReset(keyEvent, *literal);
+        return;
     } else if (keyEvent.key().check(FcitxKey_Tab)) {
         chewingReturnValue = chewing_handle_Tab(ctx);
     } else if (keyEvent.key().isSimple()) {
         if (keyEvent.rawKey().states().test(KeyState::Shift)) {
             chewing_set_easySymbolInput(ctx, *config_.EasySymbolInput ? 1 : 0);
         }
-        int scan_code = keyEvent.key().sym() & 0xff;
+        int scan_code = chewingKeyCodeForEvent(config_, keyEvent);
         if (*config_.Layout == ChewingLayout::HanYuPinYin) {
             auto zuin = safeChewing_bopomofo_String(ctx);
             // Workaround a bug in libchewing fixed in 2017 but never has

--- a/src/eim.cpp
+++ b/src/eim.cpp
@@ -109,6 +109,28 @@ bool isHsuFirstToneKey(const ChewingConfig &config, const KeyEvent &keyEvent) {
     return unicode == 'q' || unicode == 'Q';
 }
 
+bool isPreeditCommitKey(const ChewingConfig &config, const KeyEvent &keyEvent) {
+    return keyEvent.key().check(FcitxKey_space) ||
+           keyEvent.key().check(FcitxKey_Return) ||
+           isHsuFirstToneKey(config, keyEvent);
+}
+
+bool shouldCommitPreedit(const ChewingConfig &config, const KeyEvent &keyEvent,
+                         ChewingContext *ctx) {
+    return isPreeditCommitKey(config, keyEvent) &&
+           (!isHsuFirstToneKey(config, keyEvent) ||
+            !chewing_bopomofo_Check(ctx));
+}
+
+void commitAndCleanPreedit(ChewingContext *ctx, InputContext *ic) {
+    chewing_commit_preedit_buf(ctx);
+    if (chewing_commit_Check(ctx)) {
+        ic->commitString(safeChewing_commit_String(ctx));
+    }
+    chewing_clean_preedit_buf(ctx);
+    chewing_clean_bopomofo_buf(ctx);
+}
+
 int chewingKeyCodeForEvent(const ChewingConfig &config,
                            const KeyEvent &keyEvent) {
     const auto key = keyEvent.key();
@@ -125,36 +147,18 @@ public:
 
     void select(InputContext *inputContext) const override {
         auto *ctx = engine_->context();
-        auto pageSize = chewing_get_candPerPage(ctx);
-        int page = (index_ / pageSize) + chewing_cand_CurrentPage(ctx);
-        int off = index_ % pageSize;
-        if (page < 0 || page >= chewing_cand_TotalPage(ctx)) {
-            return;
-        }
-        int lastPage = chewing_cand_CurrentPage(ctx);
-        while (page != chewing_cand_CurrentPage(ctx)) {
-            if (page < chewing_cand_CurrentPage(ctx)) {
-                chewing_handle_Left(ctx);
+        const bool hasCandidates = chewing_cand_TotalChoice(ctx) > 0;
+        const bool openedHere = !hasCandidates && chewing_buffer_Check(ctx) &&
+                                chewing_cand_open(ctx) == 0;
+        if ((!hasCandidates && !openedHere) ||
+            chewing_cand_choose_by_index(ctx, index_) != 0) {
+            if (openedHere) {
+                chewing_cand_close(ctx);
             }
-            if (page > chewing_cand_CurrentPage(ctx)) {
-                chewing_handle_Right(ctx);
-            }
-            /* though useless, but take care if there is a bug cause freeze */
-            if (lastPage == chewing_cand_CurrentPage(ctx)) {
-                break;
-            }
-            lastPage = chewing_cand_CurrentPage(ctx);
-        }
-        chewing_handle_Default(ctx, builtin_selectkeys[static_cast<int>(
-                                        *engine_->config().SelectionKey)][off]);
-
-        if (chewing_keystroke_CheckIgnore(ctx)) {
             return;
         }
 
-        if (chewing_commit_Check(ctx)) {
-            inputContext->commitString(safeChewing_commit_String(ctx));
-        }
+        commitAndCleanPreedit(ctx, inputContext);
         engine_->updateUI(inputContext);
     }
 
@@ -196,30 +200,39 @@ public:
         labels_.clear();
         cursor_ = 0;
 
-        int index = 0;
-        // get candidate word
+        const bool openedPreview =
+            chewing_cand_TotalChoice(ctx) <= 0 && chewing_buffer_Check(ctx) &&
+            !chewing_bopomofo_Check(ctx) && chewing_cand_open(ctx) == 0;
+        previewOnly_ = openedPreview;
+
         int pageSize = chewing_cand_ChoicePerPage(ctx);
-        if (pageSize <= 0) {
-            return;
-        }
-        chewing_cand_Enumerate(ctx);
-        while (chewing_cand_hasNext(ctx) && index < pageSize) {
-            candidateWords_.emplace_back(std::make_unique<ChewingCandidateWord>(
-                engine_, chewing_cand_String_static(ctx), index));
-            if (index < 10) {
-                const char label[] = {
-                    builtin_selectkeys[static_cast<int>(
-                        *engine_->config().SelectionKey)][index],
-                    '.', '\0'};
-                labels_.emplace_back(label);
-            } else {
-                labels_.emplace_back();
+        if (pageSize > 0 && chewing_cand_TotalChoice(ctx) > 0) {
+            int index = 0;
+            chewing_cand_Enumerate(ctx);
+            while (chewing_cand_hasNext(ctx) && index < pageSize) {
+                candidateWords_.emplace_back(
+                    std::make_unique<ChewingCandidateWord>(
+                        engine_, chewing_cand_String_static(ctx), index));
+                if (index < 10) {
+                    const char label[] = {
+                        builtin_selectkeys[static_cast<int>(
+                            *engine_->config().SelectionKey)][index],
+                        '.', '\0'};
+                    labels_.emplace_back(label);
+                } else {
+                    labels_.emplace_back();
+                }
+                index++;
             }
-            index++;
+        }
+
+        if (openedPreview) {
+            chewing_cand_close(ctx);
         }
     }
 
     int size() const override { return candidateWords_.size(); }
+    bool previewOnly() const { return previewOnly_; }
     int cursorIndex() const override {
         if (empty() || !*engine_->config().selectCandidateWithArrowKey) {
             return -1;
@@ -309,6 +322,7 @@ private:
     InputContext *ic_;
     std::vector<std::unique_ptr<ChewingCandidateWord>> candidateWords_;
     std::vector<Text> labels_;
+    bool previewOnly_ = false;
     int cursor_ = 0;
 };
 
@@ -433,7 +447,7 @@ bool ChewingEngine::handleCandidateKeyEvent(const KeyEvent &keyEvent) const {
     auto *ic = keyEvent.inputContext();
     auto candidateList = std::dynamic_pointer_cast<ChewingCandidateList>(
         ic->inputPanel().candidateList());
-    if (!candidateList) {
+    if (!candidateList || candidateList->previewOnly()) {
         return false;
     }
 
@@ -500,17 +514,26 @@ void ChewingEngine::commitLiteralAndReset(KeyEvent &keyEvent, char literal) {
     auto *ctx = context_.get();
     auto *ic = keyEvent.inputContext();
     if (chewing_buffer_Check(ctx) || chewing_bopomofo_Check(ctx)) {
-        chewing_commit_preedit_buf(ctx);
-        if (chewing_commit_Check(ctx)) {
-            ic->commitString(safeChewing_commit_String(ctx));
-        }
+        commitAndCleanPreedit(ctx, ic);
     }
     ic->commitString(std::string(1, literal));
     chewing_cand_close(ctx);
-    chewing_clean_preedit_buf(ctx);
-    chewing_clean_bopomofo_buf(ctx);
     keyEvent.filterAndAccept();
     updateUI(ic);
+}
+
+bool ChewingEngine::commitPreedit(KeyEvent &keyEvent) {
+    auto *ctx = context_.get();
+    if (!chewing_buffer_Check(ctx)) {
+        return false;
+    }
+
+    auto *ic = keyEvent.inputContext();
+    chewing_cand_close(ctx);
+    commitAndCleanPreedit(ctx, ic);
+    keyEvent.filterAndAccept();
+    updateUI(ic);
+    return true;
 }
 
 void ChewingEngine::keyEvent(const InputMethodEntry &entry,
@@ -523,6 +546,11 @@ void ChewingEngine::keyEvent(const InputMethodEntry &entry,
 
     chewing_set_easySymbolInput(ctx, 0);
     CHEWING_DEBUG() << "KeyEvent: " << keyEvent.key().toString();
+
+    if (shouldCommitPreedit(config_, keyEvent, ctx) &&
+        commitPreedit(keyEvent)) {
+        return;
+    }
 
     if (handleCandidateKeyEvent(keyEvent)) {
         keyEvent.filterAndAccept();
@@ -635,7 +663,14 @@ void ChewingEngine::filterKey(const InputMethodEntry & /*entry*/,
         return;
     }
     auto *ic = keyEvent.inputContext();
-    if (ic->inputPanel().candidateList() &&
+    auto candidateList = ic->inputPanel().candidateList();
+    auto chewingCandidateList =
+        candidateList
+            ? std::dynamic_pointer_cast<ChewingCandidateList>(candidateList)
+            : nullptr;
+    if (candidateList &&
+        (!chewingCandidateList || !chewingCandidateList->previewOnly()) &&
+        !isPreeditCommitKey(config_, keyEvent) &&
         (keyEvent.key().isSimple() || keyEvent.key().isCursorMove() ||
          keyEvent.key().check(FcitxKey_space, KeyState::Shift) ||
          keyEvent.key().check(FcitxKey_Tab) ||

--- a/src/eim.h
+++ b/src/eim.h
@@ -213,6 +213,7 @@ public:
 
 private:
     bool handleCandidateKeyEvent(const KeyEvent &keyEvent) const;
+    bool commitPreedit(KeyEvent &keyEvent);
     void commitLiteralAndReset(KeyEvent &keyEvent, char literal);
     void updatePreeditImpl(InputContext *ic);
 

--- a/src/eim.h
+++ b/src/eim.h
@@ -213,6 +213,7 @@ public:
 
 private:
     bool handleCandidateKeyEvent(const KeyEvent &keyEvent) const;
+    void commitLiteralAndReset(KeyEvent &keyEvent, char literal);
     void updatePreeditImpl(InputContext *ic);
 
     FCITX_ADDON_DEPENDENCY_LOADER(chttrans, instance_->addonManager());


### PR DESCRIPTION
## Summary

This fixes Chewing runtime config loss after reset and improves Hsu/zhuyin input behavior, especially for fcitx5-android.

Main fix:

- reapply Chewing runtime config after `chewing_Reset()` so input-context resets keep the selected keyboard layout

Related Hsu / zhuyin input fixes:

- make Hsu `q` / `Q` work as first-tone finalization while composing bopomofo
- pass ASCII punctuation, uppercase letters, and zhuyin-layout numbers/spaces through as half-width literal text
- keep pinyin-layout number keys available for tone input
- stop using Space to page/select candidates; Space only finalizes the current bopomofo syllable, otherwise it commits a half-width space for zhuyin layouts
- make candidate display work for Android without letting the candidate list intercept normal typing
- make Android candidate taps select and commit the chosen candidate immediately, matching mobile keyboard behavior

## Root cause

Some frontends, especially fcitx5-android, can reset the Chewing engine during normal input-context lifecycle changes. In practice, the Chewing plugin can load the configured keyboard layout correctly for the first input after reload, but later input may behave as if the engine had fallen back to the default layout.

The issue is that `chewing_Reset()` resets libchewing runtime state, but the wrapper did not reapply runtime options afterwards. Settings such as the selected keyboard layout are applied through libchewing runtime calls, so they need to be restored after reset as well as after config reload.

This is especially visible with Hsu keyboard because its key mapping differs significantly from the default layout. After reset, Hsu input can stop composing correctly even though the frontend setting still shows Hsu selected.

Android also exposes a mobile-style candidate flow. The existing candidate path assumes desktop-style candidate-window state: selecting a candidate changes preedit first, and another key commits it. On Android, candidate taps are expected to commit the selected text immediately while normal typing continues without the candidate window eating Space, Enter, or Hsu `q`.

## Behavior after this change

After every Chewing reset, the plugin calls `populateConfig()` again before updating UI state. This keeps the libchewing context aligned with the configured Chewing options across input-context resets.

The literal handling changes make zhuyin/Hsu input consistently use half-width ASCII unless full-width conversion is explicitly requested elsewhere:

- Hsu `q` / `Q` is treated as a first-tone finalization key while composing bopomofo
- uppercase letters commit uppercase ASCII instead of being interpreted as zhuyin input
- ASCII punctuation commits half-width ASCII
- for non-pinyin layouts, numbers and spaces commit half-width ASCII
- pinyin layouts still keep digit keys for tone input
- Space no longer pages/selects candidates; when not composing bopomofo, it commits a normal half-width space for zhuyin layouts
- Android can show candidate choices while normal typing remains usable
- tapping an Android candidate chooses it, commits it, clears the preedit buffer, and keeps Space / Enter / Hsu `q` as fallback commit keys

## Validation

- `clang-format --dry-run --Werror src/eim.cpp src/eim.h`
- `git diff --check`
- built desktop fcitx5-chewing locally with `cmake --build build -j$(nproc)`
- attempted `ctest --test-dir build --output-on-failure`; local test currently fails because this environment cannot load the full chewing dictionary and falls back to the mini dictionary, changing expected candidate output
- built Android plugin locally with `./gradlew :plugin:chewing:assembleRelease --no-daemon`
- verified locally signed arm64 Android plugin APK with `apksigner verify --verbose`
- manually installed locally signed arm64 fcitx5-android Chewing plugin APK and tested:
  - selected Hsu layout remains effective after reload/reset
  - Hsu `q` / `Q` first-tone behavior
  - ASCII punctuation stays half-width
  - long-press uppercase letters commit uppercase ASCII
  - Space does not page/select candidates
  - Space / Enter / Hsu `q` can commit preedit text
  - Android candidate list appears during input
  - tapping a candidate commits it directly to the input field
