### PR TITLE
Handle keypad Enter like Return

### DIFF
--- a/src/eim.cpp
+++ b/src/eim.cpp
@@ -440,7 +440,8 @@ bool ChewingEngine::handleCandidateKeyEvent(const KeyEvent &keyEvent) const {
         }
         return true;
     }
-    if (keyEvent.key().check(FcitxKey_Return)) {
+    if ((keyEvent.key().check(FcitxKey_Return) ||
+         keyEvent.key().check(FcitxKey_KP_Enter))) {
         if (int index = candidateList->cursorIndex();
             index >= 0 && index < candidateList->size()) {
             candidateList->candidate(index).select(ic);
@@ -539,7 +540,8 @@ void ChewingEngine::keyEvent(const InputMethodEntry &entry,
         chewingReturnValue = chewing_handle_ShiftLeft(ctx);
     } else if (keyEvent.key().check(FcitxKey_Right, KeyState::Shift)) {
         chewingReturnValue = chewing_handle_ShiftRight(ctx);
-    } else if (keyEvent.key().check(FcitxKey_Return)) {
+    } else if ((keyEvent.key().check(FcitxKey_Return) ||
+                keyEvent.key().check(FcitxKey_KP_Enter))) {
         chewingReturnValue = chewing_handle_Enter(ctx);
     } else if (keyEvent.key().states() == KeyState::Ctrl &&
                Key(keyEvent.key().sym()).isDigit()) {

--- a/test/testchewing.cpp
+++ b/test/testchewing.cpp
@@ -63,10 +63,12 @@ void testBasic(Instance *instance) {
         ic->inputPanel().candidateList()->toCursorModifiable()->setCursorIndex(
             6);
         FCITX_ASSERT(ic->inputPanel().candidateList()->cursorIndex() == 6);
+        // Keypad Enter should select the highlighted candidate and then commit,
+        // just like Return.
         FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
-            uuid, Key("Return"), false));
+            uuid, Key(FcitxKey_KP_Enter), false));
         FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
-            uuid, Key("Return"), false));
+            uuid, Key(FcitxKey_KP_Enter), false));
 
         RawConfig config;
         config.setValueByPath("Layout", "Han-Yu PinYin Keyboard");

--- a/test/testchewing.cpp
+++ b/test/testchewing.cpp
@@ -50,13 +50,25 @@ void testBasic(Instance *instance) {
         FCITX_ASSERT(ic->inputPanel().preedit().toString() == "ㄈㄣ");
         FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
             uuid, Key("space"), false));
+        FCITX_ASSERT(!ic->inputPanel().candidateList());
+        std::string text = ic->inputPanel().preedit().toString();
+        testfrontend->call<ITestFrontend::pushCommitExpectation>(text);
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key(FcitxKey_KP_Enter), false));
+
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("z"), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("p"), false));
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("space"), false));
         FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
             uuid, Key("Down"), false));
         FCITX_ASSERT(ic->inputPanel().candidateList());
         FCITX_ASSERT(!ic->inputPanel().candidateList()->empty());
         // This should be the case.
         FCITX_ASSERT(ic->inputPanel().candidateList()->size() >= 7);
-        std::string text =
+        text =
             ic->inputPanel().candidateList()->candidate(6).text().toString();
 
         testfrontend->call<ITestFrontend::pushCommitExpectation>(text);

--- a/test/testchewing.cpp
+++ b/test/testchewing.cpp
@@ -68,8 +68,7 @@ void testBasic(Instance *instance) {
         FCITX_ASSERT(!ic->inputPanel().candidateList()->empty());
         // This should be the case.
         FCITX_ASSERT(ic->inputPanel().candidateList()->size() >= 7);
-        text =
-            ic->inputPanel().candidateList()->candidate(6).text().toString();
+        text = ic->inputPanel().candidateList()->candidate(6).text().toString();
 
         testfrontend->call<ITestFrontend::pushCommitExpectation>(text);
         ic->inputPanel().candidateList()->toCursorModifiable()->setCursorIndex(


### PR DESCRIPTION
## Summary

- handle FcitxKey_KP_Enter like FcitxKey_Return while selecting candidates
- route keypad Enter to chewing_handle_Enter during regular composition
- cover both paths in testBasic

## Problem

On systems where the keypad Enter key is reported as FcitxKey_KP_Enter, Chewing ignores the key while a composition or candidate list is active. The key then reaches the client, requiring another Enter press and appearing as a double-Enter issue.

## Testing

- cmake --fresh -S . -B build
- cmake --build build -j2
- ctest --test-dir build --output-on-failure
- verified on KDE Plasma after reboot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keypad Enter now behaves like Return during Chewing input.
  * Pressing keypad Enter can select the highlighted candidate and commit the input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->